### PR TITLE
feature: Tailwind CSS での デフォルトフォント設定のテスト

### DIFF
--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -32,8 +32,10 @@ console.log(
 
 import { createApp } from "vue";
 import "../stylesheets/style.css";
+import App from "../vue/App.vue"; // テスト用 Vue コンポーネントを読み込む
 import SignIn from "../components/SignIn.vue";
 
 document.addEventListener("DOMContentLoaded", () => {
+  createApp(App).mount("#app"); // vue/index の場所にマウント
   createApp(SignIn).mount("#sign-in");
 });

--- a/app/frontend/stylesheets/style.css
+++ b/app/frontend/stylesheets/style.css
@@ -1,3 +1,14 @@
+/* Google Fonts のインポート */
+@import url("https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* デフォルトフォントの設定 */
+@layer base {
+  html {
+    font-family: Ubuntu, "Noto Sans JP"; /* 欧文フォントと和文フォントを設定 */
+  }
+}

--- a/app/frontend/vue/App.vue
+++ b/app/frontend/vue/App.vue
@@ -1,6 +1,10 @@
 <template>
   <p>{{ state.message }}</p>
-  <div class="text-3xl font-bold underline">Hello world!</div>
+  <div>Hello world!</div>
+  <div>Font Test: Hello Everyone, It's rainy day.</div>
+  <div>これは日本語フォント適用確認用</div>
+  <div class="text-3xl text-red-500">Font Test: This is Huge font!</div>
+  <div class="text-3xl text-blue-500">これはでっけえフォントです</div>
 </template>
 
 <script>
@@ -11,7 +15,7 @@ export default defineComponent({
   setup() {
     return {
       state: {
-        message: "Hello Vue3 + TypeScript!",
+        message: "Hello, Rails + Vue.js + Tailwind CSS!",
       },
     };
   },


### PR DESCRIPTION
# Tailwind CSS を用いたデフォルトフォントの設定

試しに欧文フォントに "Ubuntu"
和文フォントに "Noto Sans Japanese" を設定してみた

```shell
bundle exec rails s
```
上記コマンドでローカルサーバーを立ち上げて

`http://127.0.0.1:3000/vue/index`

にアクセスするとフォントのテストページを閲覧できる
