### PR TITLE
feat: app_usersにaccount_typeとcorporateカラムを追加

### DIFF
--- a/app/models/app_user.rb
+++ b/app/models/app_user.rb
@@ -3,9 +3,42 @@ class AppUser < ApplicationRecord
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
   validates :account_status, inclusion: { in: %w[active inactive suspended] }
+  validates :account_type, inclusion: { in: %w[individual corporate], message: "must be 'individual' or 'corporate'" }
+  validates :corporate_type, presence: true, if: -> { account_type == "corporate" }
+  validates :corporate_type, inclusion: { in: CORPORATE_TYPES }, allow_nil: true
+  validate :corporate_type_must_be_nil_for_individual
+
+  # 法人の種類のリスト
+  CORPORATE_TYPES = [
+    "株式会社",
+    "有限会社",
+    "合同会社",
+    "合資会社",
+    "一般社団法人",
+    "一般財団法人",
+    "公益社団法人",
+    "公益財団法人",
+    "独立行政法人",
+    "国立大学法人",
+    "地方独立行政法人",
+    "公立大学法人",
+    "学校法人",
+    "宗教法人",
+    "医療法人",
+    "社会福祉法人"
+  ].freeze
 
   # アソシエーション: 他のモデルとの関連付け
   has_many :stamps
   has_many :reviews
   has_many :user_rewards
+
+  private
+
+  # 一般ユーザの場合、法人種類はnilでなければならない
+  def corporate_type_must_be_nil_for_individual
+    if account_type == "individual" && corporate_type.present?
+      errors.add(:corporate_type, "must be blank for individual accounts")
+    end
+  end
 end

--- a/db/migrate/20241115024921_add_account_type_and_corporate_type_to_app_users.rb
+++ b/db/migrate/20241115024921_add_account_type_and_corporate_type_to_app_users.rb
@@ -1,0 +1,6 @@
+class AddAccountTypeAndCorporateTypeToAppUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :app_users, :account_type, :string, null: false, default: "individual"
+    add_column :app_users, :corporate_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_14_014650) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_15_024921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_14_014650) do
     t.text "location"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "account_type", default: "individual", null: false
+    t.string "corporate_type"
   end
 
   create_table "categories", force: :cascade do |t|


### PR DESCRIPTION
## やったこと
モデルの修正
`app_user` に `account_type` と `corporate_type` を追加

## できるようになること
`app_users` テーブルと会員タイプと法人タイプをやり取り出来るようになりました

## できなくなること
特になし

## 注意点
データベースを反映させるため各自マイグレーション作業をお願いします