### PR TITLE
fix: 重複したコードを排除

### DIFF
--- a/db/migrate/20241120010415_update_model_courses_table.rb
+++ b/db/migrate/20241120010415_update_model_courses_table.rb
@@ -1,8 +1,5 @@
 class UpdateModelCoursesTable < ActiveRecord::Migration[7.0]
   def change
-    # public_keyにユニークインデックスを追加
-    add_index :model_courses, :public_key, unique: true
-
     # is_publicのデフォルト値をfalseに変更
     change_column_default :model_courses, :is_public, from: true, to: false
   end


### PR DESCRIPTION
migration コマンドにて途中でコンフリクトして
migration が正常に終了しない問題を解決

```sh
bundle exec rails db:migrate
```
