### PR TITLE
chore: remove dotenv-rails gem from Gemfile and Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,5 +88,3 @@ group :test do
   gem 'capybara'
   gem 'selenium-webdriver'
 end
-
-gem 'dotenv-rails', groups: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,10 +92,6 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    dotenv (3.1.7)
-    dotenv-rails (3.1.7)
-      dotenv (= 3.1.7)
-      railties (>= 6.1)
     dry-cli (1.2.0)
     erubi (1.13.0)
     globalid (1.2.1)
@@ -285,7 +281,6 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
-  dotenv-rails
   importmap-rails
   jbuilder
   pg (~> 1.1)


### PR DESCRIPTION
This pull request includes a small change to the `Gemfile`. The change removes the `dotenv-rails` gem from the `development` and `test` groups.

* [`Gemfile`](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fL91-L92): Removed the `dotenv-rails` gem from the `development` and `test` groups.