### PR TITLE
fix: create default admin user in seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,21 +6,13 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-# サンプルユーザー
-application_user = ApplicationUser.create!(
-  user_id: 'user123',
-  nickname: 'Sample User',
-  email: 'user@example.com',
-  password: 'password123', 
-  account_type: 'individual',
-  role: 'user' # 必要に応じてロールを指定
+# Create a default admin user
+ApplicationUser.create!(
+  user_id: "admin",
+  nickname: "admin_name",
+  email: "admin@exmaple.com",
+  password: "password",
+  password_confirmation: "password",
+  account_type: "individual",
+  role: "admin"
 )
-
-# サンプルモデルコース
-5.times do |i|
-  ModelCourse.create!(
-    title: "モデルコース#{i + 1}",
-    description: "これはサンプルモデルコースです#{i + 1}",
-    application_user: application_user # 関連付け
-  )
-end


### PR DESCRIPTION
This pull request includes a change to the `db/seeds.rb` file to update the sample data. The most important change is the creation of a default admin user instead of a sample user and model courses.

Changes to seed data:

* [`db/seeds.rb`](diffhunk://#diff-c61a903a1201b0c7f076b0270377c20390c26f655ce63689d7d843296fcf63f3L9-L26): Removed the creation of a sample user and associated model courses, and added the creation of a default admin user with specified credentials.