### PR TITLE
refactor: change UUID to bigint for model_courses and update foreign …

### DIFF
--- a/db/migrate/20250206100646_change_uuid_to_bigint.rb
+++ b/db/migrate/20250206100646_change_uuid_to_bigint.rb
@@ -2,7 +2,6 @@ class ChangeUuidToBigint < ActiveRecord::Migration[7.0]
   def change
     # 外部キー制約を削除
     remove_foreign_key :course_spots, :model_courses
-    remove_foreign_key :model_course_images, :model_courses
 
     # `model_courses` の `id` を変更
     remove_column :model_courses, :id, :uuid
@@ -12,12 +11,7 @@ class ChangeUuidToBigint < ActiveRecord::Migration[7.0]
     remove_column :course_spots, :model_course_id
     add_column :course_spots, :model_course_id, :bigint, null: false
 
-    # `model_course_images` の `model_course_id` を `bigint` に変更
-    remove_column :model_course_images, :model_course_id
-    add_column :model_course_images, :model_course_id, :bigint, null: false
-
     # 外部キー制約を再追加
-    add_foreign_key :course_spots, :model_courses, column: :model_course_id, on_delete: :cascade
-    add_foreign_key :model_course_images, :model_courses, column: :model_course_id, on_delete: :cascade
+    add_foreign_key :course_spots, :model_courses
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -222,13 +222,12 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_09_094024) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "categories_spots", "categories"
   add_foreign_key "categories_spots", "spots"
-  add_foreign_key "course_spots", "model_courses", on_delete: :cascade
+  add_foreign_key "course_spots", "model_courses"
   add_foreign_key "course_spots", "spots"
   add_foreign_key "event_categories", "categories"
   add_foreign_key "event_categories", "events"
   add_foreign_key "events", "spots"
   add_foreign_key "logs", "application_users"
-
   add_foreign_key "model_courses", "application_users"
   add_foreign_key "reviews", "application_users"
   add_foreign_key "reviews", "spots"


### PR DESCRIPTION
This pull request involves changes to the database schema and migration files to update the foreign key constraints and modify column types. The most important changes include removing and re-adding foreign key constraints, and changing the `model_course_id` column type in the `course_spots` table.

Database schema and migration updates:

* [`db/migrate/20250206100646_change_uuid_to_bigint.rb`](diffhunk://#diff-7a330754abe0e43f38752a5bc2c8a9537a344d92e09e8dd32d1ab6051a8f9d91L5): Removed the foreign key constraint from the `course_spots` table and re-added it without the `on_delete: :cascade` option. Also removed the removal and addition of the `model_course_id` column in the `model_course_images` table. [[1]](diffhunk://#diff-7a330754abe0e43f38752a5bc2c8a9537a344d92e09e8dd32d1ab6051a8f9d91L5) [[2]](diffhunk://#diff-7a330754abe0e43f38752a5bc2c8a9537a344d92e09e8dd32d1ab6051a8f9d91L15-R15)
* [`db/schema.rb`](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L225-L231): Updated the foreign key constraint for the `course_spots` table to remove the `on_delete: :cascade` option.